### PR TITLE
[fix] redux-persist 호환을 위한 정적 session slice 등록

### DIFF
--- a/src/entities/session/session.model.ts
+++ b/src/entities/session/session.model.ts
@@ -1,11 +1,10 @@
-import type { PayloadAction, WithSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import { rootReducer } from '~shared/store';
 import type { User } from './session.type';
 
 type State = User | null;
 
-const sessionSlice = createSlice({
+export const sessionSlice = createSlice({
   name: 'session',
   initialState: null as State,
   reducers: {
@@ -18,11 +17,4 @@ const sessionSlice = createSlice({
 });
 
 export const { setSession, resetSession } = sessionSlice.actions;
-
-declare module '~shared/store' {
-  export interface LazyLoadedSlices extends WithSlice<typeof sessionSlice> {}
-}
-
-const injectedSessionSlice = sessionSlice.injectInto(rootReducer);
-
-export const { selectSession } = injectedSessionSlice.selectors;
+export const { selectSession } = sessionSlice.selectors;

--- a/src/shared/store.ts
+++ b/src/shared/store.ts
@@ -1,14 +1,14 @@
 import { combineSlices, configureStore } from '@reduxjs/toolkit';
 import { persistReducer, persistStore, FLUSH, PAUSE, PERSIST, PURGE, REGISTER, REHYDRATE } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
+import { sessionSlice } from '~entities/session/session.model';
 
-export interface LazyLoadedSlices {}
-
-export const rootReducer = combineSlices().withLazyLoadedSlices<LazyLoadedSlices>();
+export const rootReducer = combineSlices(sessionSlice);
 
 const persistConfig = {
   key: 'root',
   storage,
+  whitelist: ['session'],
 };
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);


### PR DESCRIPTION
## Summary

redux-persist와 lazy loading slice의 호환성 문제를 해결합니다.

**문제 상황:**
세션 slice를 lazy loading 방식으로 구현했으나, redux-persist는 스토어 초기화 시점에 모든 reducer 구조를 알아야 합니다. 런타임에 동적으로 추가되는 slice는 영속화 설정에 포함되지 않아 새로고침 시 세션 상태가 복원되지 않는 문제가 발생했습니다.

**해결 방법:**
세션은 애플리케이션 전역에서 필수적으로 사용되므로, lazy loading의 이점이 없습니다. 따라서 정적으로 등록하여 redux-persist가 초기화 시점에 인식할 수 있도록 변경했습니다.

## Changes

### 아키텍처 변경

**Before: Lazy Loading**
```typescript
// 런타임에 동적 주입
const injectedSlice = sessionSlice.injectInto(rootReducer);
```

**After: Static Registration**
```typescript
// 초기화 시점에 정적 등록
combineSlices(sessionSlice);
```

### redux-persist 설정 강화

- `whitelist: ['session']` 추가로 영속화 대상 명시적 지정
- 불필요한 상태가 storage에 저장되는 것을 방지
- 새로고침 시 세션 상태 정상 복원

### 주의사항

⚠️ **다른 slice 영속화 필요 시**
- `whitelist` 배열에 추가 필요
- 예: `whitelist: ['session', 'settings']`

⚠️ **정적 등록 vs Lazy Loading 판단 기준**
- 전역에서 항상 사용: 정적 등록 (예: session, theme)
- 특정 페이지/기능만 사용: lazy loading 유지 (예: editor, article detail)

⚠️ **번들 크기 영향**
- session slice는 필수 기능이므로 정적 등록해도 번들 크기 증가 없음
- 다른 slice는 필요성을 검토 후 결정

## Checklist
- [x] 로컬에서 테스트 완료
- [x] 커밋 메시지가 가이드라인을 따름
- [x] 새로고침 시 세션 복원 동작 확인
- [x] redux-persist 설정 검증 완료
