### PR TITLE
[feat] Tag Entity 모듈 추가 (TanStack Query 통합)

### DIFF
--- a/src/entities/tag/tag.api.ts
+++ b/src/entities/tag/tag.api.ts
@@ -1,0 +1,14 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getAllTags } from '~shared/api/api.service';
+import { transformTagsDtoToTags } from './tag.lib';
+
+export const tagsQueryOptions = queryOptions({
+  queryKey: ['tags'],
+
+  queryFn: async () => {
+    const data = await getAllTags();
+    const tags = transformTagsDtoToTags(data);
+
+    return tags;
+  },
+});

--- a/src/entities/tag/tag.contracts.ts
+++ b/src/entities/tag/tag.contracts.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const TagsSchema = z.array(z.string());

--- a/src/entities/tag/tag.lib.ts
+++ b/src/entities/tag/tag.lib.ts
@@ -1,0 +1,6 @@
+import type { TagsDto } from '~shared/api/api.schemas';
+import type { Tags } from './tag.type';
+
+export function transformTagsDtoToTags(tagsDto: TagsDto): Tags {
+  return tagsDto.tags;
+}

--- a/src/entities/tag/tag.type.ts
+++ b/src/entities/tag/tag.type.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod';
+import type { TagsSchema } from './tag.contracts';
+
+export type Tags = z.infer<typeof TagsSchema>;

--- a/src/shared/api/api.schemas.ts
+++ b/src/shared/api/api.schemas.ts
@@ -73,6 +73,10 @@ export const FilterQueryDtoSchema = z.object({
   favorited: z.string().optional(),
 });
 
+export const TagsDtoSchema = z.object({
+  tags: z.array(z.string()),
+});
+
 export type RegisterUserDto = z.infer<typeof RegisterUserDtoSchema>;
 export type LoginUserDto = z.infer<typeof LoginUserDtoSchema>;
 export type UserDto = z.infer<typeof UserDtoSchema>;
@@ -83,3 +87,5 @@ export type ProfileDto = z.infer<typeof ProfileDtoSchema>;
 export type ArticleDto = z.infer<typeof ArticleDtoSchema>;
 export type ArticlesDto = z.infer<typeof ArticlesDtoSchema>;
 export type FilterQueryDto = z.infer<typeof FilterQueryDtoSchema>;
+
+export type TagsDto = z.infer<typeof TagsDtoSchema>;

--- a/src/shared/api/api.service.ts
+++ b/src/shared/api/api.service.ts
@@ -8,6 +8,7 @@ import {
   ProfileDtoSchema,
   RefreshResponseDtoSchema,
   RegisterUserDtoSchema,
+  TagsDtoSchema,
   UserDtoSchema,
   type ArticleDto,
   type ArticlesDto,
@@ -15,6 +16,7 @@ import {
   type ProfileDto,
   type RefreshResponseDto,
   type RegisterUserDto,
+  type TagsDto,
   type UserDto,
 } from './api.schemas';
 
@@ -90,6 +92,13 @@ export async function getAllArticles(config?: AxiosRequestConfig): Promise<Artic
 export async function getFeedArticles(config?: AxiosRequestConfig): Promise<ArticlesDto> {
   const response = await privateApi.get('/articles/feed', config);
   const parsedResponse = ArticlesDtoSchema.parse(response.data);
+
+  return parsedResponse;
+}
+
+export async function getAllTags(config?: AxiosRequestConfig): Promise<TagsDto> {
+  const response = await publicApi.get('/tags', config);
+  const parsedResponse = TagsDtoSchema.parse(response.data);
 
   return parsedResponse;
 }


### PR DESCRIPTION
## Summary

모든 태그를 조회하는 Entity 모듈을 추가하여 태그 목록을 TanStack Query로 관리합니다. 공개 API로 로그인 없이 태그를 조회할 수 있습니다.

## Changes

### Tag Entity 모듈 추가

- tag.type.ts: Tags 타입 정의 (문자열 배열)
- tag.contracts.ts: TagsSchema (Zod 검증, 문자열 배열)
- tag.lib.ts: transformTagsDtoToTags() 변환 함수 (TagsDto.tags 추출)
- tag.api.ts: tagsQueryOptions() Query 옵션 (queryKey: [tags])

### API 계층

- api.schemas.ts: TagsDtoSchema 추가 (tags 배열)
- api.service.ts: getAllTags() 함수 (GET /tags, publicApi 사용)


## 주요 포인트

### 단순한 구조
- Tags는 문자열 배열만 포함
- 변환 함수는 단순 추출 (tagsDto.tags)
- 정적 데이터 (자주 변경 안 함)

### 공개 API
- publicApi 사용 (로그인 불필요)
- 모든 사용자가 조회 가능
- 필터링에 사용될 태그 목록

### Entity 패턴 일관성
- Profile Entity와 동일한 구조
- Article Entity와 동일한 구조
- 4개 파일 + 2개 스키마 추가

### Query 캐싱
- TanStack Query로 자동 캐싱
- 서버 상태 동기화
- 중복 요청 제거


## 구현 흐름

```text
GET /tags
  ↓
TagsDto: { tags: ['javascript', 'typescript', ...] }
  ↓
Zod 검증 (TagsDtoSchema)
  ↓
transformTagsDtoToTags()
  ↓
Tags: ['javascript', 'typescript', ...]
  ↓
tagsQueryOptions()
  ↓
TanStack Query (캐싱)
  ↓
UI 렌더링
```

## 사용 예

```typescript
const { data: tags } = useSuspenseQuery(tagsQueryOptions);

result: ['javascript', 'typescript', 'nestjs', ...]
```

필터에서 사용:
```typescript
const filteredByTag = articles.filter(
  article => article.tags.includes(selectedTag)
);
```

## Checklist

- [x] Tags 타입 정의
- [x] TagsSchema 스키마 (Zod)
- [x] 변환 함수 구현
- [x] Query 옵션 설정
- [x] getAllTags() 함수 추가
- [x] publicApi 사용 (인증 불필요)
- [x] Profile/Article과 일관된 패턴