### PR TITLE
[feat] Comment Entity 모듈 추가 (TanStack Query 통합)

### DIFF
--- a/src/entities/comment/comment.api.ts
+++ b/src/entities/comment/comment.api.ts
@@ -1,0 +1,15 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getAllCommentsBySlug } from '~shared/api/api.service';
+import { transformCommentsDtoToComments } from './comment.lib';
+
+export const commentsQueryOptions = (slug: string) =>
+  queryOptions({
+    queryKey: ['comments', slug],
+
+    queryFn: async ({ signal }) => {
+      const data = await getAllCommentsBySlug(slug, { signal });
+      const comments = transformCommentsDtoToComments(data);
+
+      return comments;
+    },
+  });

--- a/src/entities/comment/comment.contracts.ts
+++ b/src/entities/comment/comment.contracts.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+import { CommentDtoSchema } from '~shared/api/api.schemas';
+
+export const CommentSchema = CommentDtoSchema.shape.comment;
+export const CommentsSchema = z.array(CommentSchema);

--- a/src/entities/comment/comment.lib.ts
+++ b/src/entities/comment/comment.lib.ts
@@ -1,0 +1,20 @@
+import type { CommentDto, CommentsDto } from '~shared/api/api.schemas';
+import type { Comment, Comments } from './comment.type';
+
+export function transformCommentDtoToComment(commentDto: CommentDto): Comment {
+  const { comment } = commentDto;
+
+  return {
+    ...comment,
+    author: {
+      ...comment.author,
+      image: comment.author.image ?? '',
+      bio: comment.author.bio ?? '',
+      following: comment.author.following ?? false,
+    },
+  };
+}
+
+export function transformCommentsDtoToComments(commentsDto: CommentsDto): Comments {
+  return commentsDto.comments;
+}

--- a/src/entities/comment/comment.type.ts
+++ b/src/entities/comment/comment.type.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+import type { CommentSchema, CommentsSchema } from './comment.contracts';
+
+export type Comment = z.infer<typeof CommentSchema>;
+export type Comments = z.infer<typeof CommentsSchema>;

--- a/src/shared/api/api.schemas.ts
+++ b/src/shared/api/api.schemas.ts
@@ -73,6 +73,20 @@ export const FilterQueryDtoSchema = z.object({
   favorited: z.string().optional(),
 });
 
+export const CommentDtoSchema = z.object({
+  comment: z.object({
+    id: z.uuid(),
+    createdAt: z.iso.datetime(),
+    updatedAt: z.iso.datetime(),
+    body: z.string(),
+    author: ProfileDtoSchema.shape.profile,
+  }),
+});
+
+export const CommentsDtoSchema = z.object({
+  comments: z.array(CommentDtoSchema.shape.comment),
+});
+
 export const TagsDtoSchema = z.object({
   tags: z.array(z.string()),
 });
@@ -87,5 +101,8 @@ export type ProfileDto = z.infer<typeof ProfileDtoSchema>;
 export type ArticleDto = z.infer<typeof ArticleDtoSchema>;
 export type ArticlesDto = z.infer<typeof ArticlesDtoSchema>;
 export type FilterQueryDto = z.infer<typeof FilterQueryDtoSchema>;
+
+export type CommentDto = z.infer<typeof CommentDtoSchema>;
+export type CommentsDto = z.infer<typeof CommentsDtoSchema>;
 
 export type TagsDto = z.infer<typeof TagsDtoSchema>;

--- a/src/shared/api/api.service.ts
+++ b/src/shared/api/api.service.ts
@@ -4,6 +4,7 @@ import { privateApi, publicApi } from './api.instance';
 import {
   ArticleDtoSchema,
   ArticlesDtoSchema,
+  CommentsDtoSchema,
   LoginUserDtoSchema,
   ProfileDtoSchema,
   RefreshResponseDtoSchema,
@@ -12,6 +13,7 @@ import {
   UserDtoSchema,
   type ArticleDto,
   type ArticlesDto,
+  type CommentsDto,
   type LoginUserDto,
   type ProfileDto,
   type RefreshResponseDto,
@@ -92,6 +94,13 @@ export async function getAllArticles(config?: AxiosRequestConfig): Promise<Artic
 export async function getFeedArticles(config?: AxiosRequestConfig): Promise<ArticlesDto> {
   const response = await privateApi.get('/articles/feed', config);
   const parsedResponse = ArticlesDtoSchema.parse(response.data);
+
+  return parsedResponse;
+}
+
+export async function getAllCommentsBySlug(slug: string, config?: AxiosRequestConfig): Promise<CommentsDto> {
+  const response = await privateApi.get(`/articles/${slug}/comments`, config);
+  const parsedResponse = CommentsDtoSchema.parse(response.data);
 
   return parsedResponse;
 }


### PR DESCRIPTION
## Summary

Article Comment를 조회하고 관리하는 Entity 모듈을 추가합니다. 댓글 작성자 정보를 포함하여 TanStack Query로 캐싱합니다.


## Changes

### Comment Entity 모듈

- comment.type.ts: Comment, Comments 타입 정의
- comment.contracts.ts: CommentSchema, CommentsSchema (Zod)
- comment.lib.ts: 2개 변환 함수
  - transformCommentDtoToComment(): author null 처리
  - transformCommentsDtoToComments(): 배열 추출
- comment.api.ts: commentsQueryOptions() (queryKey: [comments, slug])

### API 계층

- api.schemas.ts
  - CommentDtoSchema: 단일 댓글 (id, createdAt, updatedAt, body, author)
  - CommentsDtoSchema: 댓글 배열

- api.service.ts
  - getAllCommentsBySlug(): GET /articles/:slug/comments (privateApi)


## Comment 데이터 구조

- id: UUID (고유 식별자)
- createdAt: ISO datetime (작성일)
- updatedAt: ISO datetime (수정일)
- body: string (댓글 내용)
- author: Profile (작성자 정보)
  - username, bio, image, following

## 주요 구현 사항

### null 처리

- author.image ?? '' (기본값: 빈 문자열)
- author.bio ?? '' (기본값: 빈 문자열)
- author.following ?? false (기본값: false)

### ProfileDtoSchema 재사용

- CommentDtoSchema의 author는 ProfileDtoSchema.shape.profile 재사용
- 코드 중복 제거 + 일관성 유지

### Query 설정

- queryKey: [comments, slug] (아티클별 캐싱)
- queryFn: signal 지원으로 요청 취소 가능

### API 인증

- privateApi 사용 (인증 필요)
- 엔드포인트: GET /articles/:slug/comments

## Entity 패턴 일관성

- Profile Entity와 동일한 구조
- Article Entity와 동일한 구조
- Tag Entity와 동일한 구조
- Comment Entity (신규, 동일 패턴)

## 데이터 흐름

1. GET /articles/:slug/comments (API 요청)
2. CommentsDto: { comments: [...] } (응답)
3. Zod 검증 (CommentsDtoSchema)
4. transformCommentsDtoToComments() (추출)
5. Comments 배열 (정규화)
6. commentsQueryOptions() (Query 설정)
7. TanStack Query (캐싱)
8. UI 렌더링

## 사용 예
```typescript
const { data: comments } = useSuspenseQuery(
  commentsQueryOptions('how-to-code')
);

comments.map(comment => (
  <div key={comment.id}>
    <p>{comment.body}</p>
    <p>by {comment.author.username}</p>
  </div>
))
```

## Checklist

- [x] Comment, Comments 타입 정의
- [x] CommentSchema, CommentsSchema (Zod)
- [x] 변환 함수 구현 (2개)
- [x] Query 옵션 설정
- [x] CommentDtoSchema, CommentsDtoSchema 추가
- [x] getAllCommentsBySlug() 함수 추가
- [x] author null 처리 (image, bio, following)
- [x] privateApi 사용 (인증 필요)
- [x] Entity 패턴 일관성 유지