### PR TITLE
[feat]: Comment 피드 위젯 구현

### DIFF
--- a/src/widgets/comments-feed/comments-feed.skeleton.tsx
+++ b/src/widgets/comments-feed/comments-feed.skeleton.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from '~shared/ui/skeleton/skeleton.ui';
+import { Stack } from '~shared/ui/stack/stack.ui';
+
+export function CommentsListSkeleton() {
+  return new Array(4).fill(0).map((_, idx) => (
+    <div key={`static-${String(idx)}`} className="card">
+      <div className="card-block">
+        <Skeleton variant="text" width="80%" />
+      </div>
+      <div className="card-footer">
+        <Stack alignItems="center" spacing={2}>
+          <Skeleton variant="circular" width={20} height={20} />
+
+          <Skeleton variant="text" height={12} width={100} />
+
+          <Skeleton variant="text" height={26} width={0} />
+
+          <Skeleton variant="text" height={12} />
+        </Stack>
+      </div>
+    </div>
+  ));
+}

--- a/src/widgets/comments-feed/comments-feed.ui.tsx
+++ b/src/widgets/comments-feed/comments-feed.ui.tsx
@@ -1,0 +1,102 @@
+import { Suspense, type ReactNode } from 'react';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { ErrorBoundary } from 'react-error-boundary';
+import { Link } from 'react-router-dom';
+import { pathKey } from '~shared/router';
+import { logError } from '~shared/ui/error-handler/error-handler.lib';
+import { ErrorHandler } from '~shared/ui/error-handler/error-handler.ui';
+import { commentsQueryOptions } from '~entities/comment/comment.api';
+import type { Comment } from '~entities/comment/comment.type';
+import { CreateCommentForm } from '~features/comment/create-comment/create-comment.ui';
+import { DeleteCommentButton } from '~features/comment/delete-comment/delete-comment.ui';
+import { useCanPerformAction } from '~features/permission/permission.service';
+import { CommentsListSkeleton } from './comments-feed.skeleton';
+
+interface CommonCommentsProps {
+  slug: string;
+}
+
+export function CommentsFeed({ slug }: CommonCommentsProps) {
+  const canCreateComment = useCanPerformAction('create', 'comment');
+
+  return (
+    <>
+      {!canCreateComment && (
+        <p>
+          <Link to={pathKey.login}>Sign in</Link> or <Link to={pathKey.register}>sign up</Link>
+          to add comments on this article.
+        </p>
+      )}
+      {canCreateComment && <CreateCommentForm slug={slug} />}
+      <CommentList slug={slug} />
+    </>
+  );
+}
+
+function CommentList({ slug }: CommonCommentsProps) {
+  return (
+    <ErrorBoundary FallbackComponent={ErrorHandler} onError={logError}>
+      <Suspense fallback={<CommentsListSkeleton />}>
+        <BaseCommentList slug={slug} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
+function BaseCommentList({ slug }: CommonCommentsProps) {
+  const { data: comments } = useSuspenseQuery(commentsQueryOptions(slug));
+
+  return (
+    <div>
+      {Array.from(comments.values())
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        .map((comment) => (
+          <CommentCard
+            key={comment.id}
+            comment={comment}
+            actions={<DeleteCommentAction slug={slug} comment={comment} />}
+          />
+        ))}
+    </div>
+  );
+}
+
+function CommentCard({ comment, actions }: { comment: Comment; actions?: ReactNode }) {
+  const { id: commentId, body, author, updatedAt } = comment;
+  const { username, image } = author;
+  const formattedDate = new Intl.DateTimeFormat('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(new Date(updatedAt));
+
+  return (
+    <div key={commentId} className="card">
+      <div className="card-block">
+        <p className="card-text">{body}</p>
+      </div>
+
+      <div className="card-footer">
+        <Link to={pathKey.profile.byUsername(username)} className="comment-author">
+          <img src={image ?? ''} alt={username} className="comment-author-img" />
+        </Link>
+
+        <Link to={pathKey.profile.byUsername(username)} className="comment-author">
+          {username}
+        </Link>
+        <span className="date-posted">{formattedDate}</span>
+        {actions}
+      </div>
+    </div>
+  );
+}
+
+function DeleteCommentAction({ slug, comment }: { slug: string; comment: Comment }) {
+  const { author, id: commentId } = comment;
+
+  const canDeleteComment = useCanPerformAction('delete', 'comment', {
+    commentAuthorId: author.username,
+  });
+
+  return canDeleteComment && <DeleteCommentButton slug={slug} commentId={commentId} />;
+}


### PR DESCRIPTION
## Summary

게시글의 댓글 목록을 표시하고 관리하는 피드 위젯을 구현합니다.
권한 기반으로 댓글 작성 및 삭제 기능을 제공하며, 비로그인 사용자에게는
로그인/회원가입을 안내하여 참여를 유도합니다. 최신순 정렬로 댓글을 표시하여
활발한 토론을 장려하고, 선언적 에러 처리와 로딩 상태 관리로 안정적인 UX를 제공합니다.

## Changes

### 댓글 피드 컴포넌트
- **CommentsFeed**: 댓글 작성 및 목록의 최상위 래퍼
  - 권한 확인: useCanPerformAction('create', 'comment')
  - 비로그인: "Sign in or sign up to add comments" 안내 + 링크
  - 로그인: CreateCommentForm 표시
  - CommentList 통합

### 댓글 목록
- **CommentList**: ErrorBoundary + Suspense 래퍼
- **BaseCommentList**: 핵심 댓글 목록 로직
  - useSuspenseQuery(commentsQueryOptions)로 데이터 조회
  - createdAt 기준 내림차순 정렬 (최신 댓글 우선)
  - Map 데이터를 Array로 변환 후 정렬

### 댓글 카드
- **CommentCard**: 개별 댓글 표시
  - 본문 (card-text)
  - 작성자 정보: 프로필 이미지, 이름 (프로필 페이지 링크)
  - 업데이트 날짜: Intl.DateTimeFormat으로 ko-KR 포맷
  - 액션 슬롯 (삭제 버튼 등)

### 권한 기반 삭제 액션
- **DeleteCommentAction**: 조건부 삭제 버튼
  - useCanPerformAction('delete', 'comment', { commentAuthorId })
  - 댓글 작성자만 삭제 버튼 표시
  - 타인의 댓글은 삭제 불가

### 로딩 스켈레톤
- **CommentsListSkeleton**: 4개 댓글 카드 스켈레톤
  - 본문 텍스트 스켈레톤 (80% 너비)
  - 작성자 정보 스켈레톤 (원형 이미지 + 텍스트)

## 기술적 특징

1. **선언적 데이터 페칭**: useSuspenseQuery로 로딩/에러 상태 통합
2. **권한 기반 UI**: useCanPerformAction으로 사용자별 기능 제어
3. **최신순 정렬**: 댓글 작성 시간 기준 내림차순으로 활발한 토론 유도
4. **다국어 지원**: Intl.DateTimeFormat으로 날짜 현지화
5. **선언적 에러 처리**: ErrorBoundary로 에러 격리 및 복구

## 사용자 경험

### 비로그인 사용자
- 댓글 목록 읽기 가능
- 로그인/회원가입 안내 메시지 표시
- 즉시 로그인 페이지로 이동 가능

### 로그인 사용자
- 댓글 작성 폼 접근 가능
- 자신의 댓글만 삭제 가능
- 타인의 댓글은 읽기 전용

### 로딩 및 에러
- 로딩 중: 4개 댓글 스켈레톤 표시
- 에러 발생: ErrorHandler로 안전한 에러 UI 표시

## 권한 관리

| 액션 | 권한 조건 | UI 표시 |
|------|-----------|---------|
| 댓글 작성 | 로그인 | CreateCommentForm |
| 댓글 읽기 | 모두 | CommentCard |
| 댓글 삭제 | 작성자 본인 | DeleteCommentButton |

## 데이터 흐름

1. CommentsFeed 마운트
2. 권한 확인 → 댓글 작성 폼 or 로그인 안내
3. useSuspenseQuery → 댓글 목록 조회
4. 최신순 정렬 → CommentCard 렌더링
5. 각 댓글마다 삭제 권한 확인 → 조건부 버튼 표시

## 주요 기능

1. 댓글 목록 표시 (최신순)
2. 권한 기반 댓글 작성 폼
3. 권한 기반 댓글 삭제
4. 비로그인 사용자 안내
5. 로딩 스켈레톤 UI
6. 에러 핸들링