### PR TITLE
[feat]: 404 페이지 구현

### DIFF
--- a/src/pages/page-404/page-404.module.css
+++ b/src/pages/page-404/page-404.module.css
@@ -1,0 +1,15 @@
+.outer-wrapper {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.inner-wrapper {
+  width: 100%;
+  padding: 2rem;
+  color: #fff;
+  text-align: center;
+  background: #333;
+}

--- a/src/pages/page-404/page-404.route.ts
+++ b/src/pages/page-404/page-404.route.ts
@@ -1,0 +1,9 @@
+import type { RouteObject } from 'react-router-dom';
+import { pathKey } from '~shared/router';
+
+export const page404Route = {
+  path: pathKey.page404,
+  lazy: {
+    Component: () => import('./page-404.ui').then((module) => module.default),
+  },
+} satisfies RouteObject;

--- a/src/pages/page-404/page-404.ui.tsx
+++ b/src/pages/page-404/page-404.ui.tsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom';
+import { pathKey } from '~shared/router';
+import * as styles from './page-404.module.css';
+
+export default function Page404() {
+  return (
+    <div className={styles['outer-wrapper']}>
+      <div className={styles['inner-wrapper']}>
+        <div className="container">
+          <h1 className="logo-font">Page not fount</h1>
+          <p>Sorry, we couldn&apos;t find the page you&apos;re looking for.</p>
+          <Link to={pathKey.home} className="btn btn-sm btn-outline-primary">
+            Go back home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

존재하지 않는 경로에 접근했을 때 표시할 404 에러 페이지를 구현합니다.
사용자 친화적인 에러 메시지와 홈 페이지로 돌아가는 버튼을 제공하여
잘못된 URL에서도 원활하게 정상 경로로 복귀할 수 있도록 지원합니다.

## Changes

### 404 페이지 컴포넌트
- **page-404.ui.tsx**: 에러 페이지 UI
  - "Page not found" 제목
  - 사과 메시지: "Sorry, we couldn't find the page you're looking for."
  - "Go back home" 버튼으로 홈 페이지 이동
  - 중앙 정렬 레이아웃

### 스타일링
- **page-404.module.css**: CSS Modules로 스타일 격리
  - outer-wrapper: 전체 화면 중앙 정렬
    - position: absolute + inset: 0
    - flexbox로 중앙 정렬
  - inner-wrapper: 콘텐츠 영역
    - #333 배경, 흰색 텍스트
    - 2rem 패딩

### 라우트 설정
- **page-404.route.ts**: Lazy loading 라우트 객체
  - 동적 import로 코드 스플리팅
  - pathKey.page404 경로 사용

## 기술적 특징

1. **CSS Modules**: 스타일 격리로 전역 CSS 충돌 방지
2. **Lazy Loading**: 404 페이지는 필요할 때만 로드
3. **중앙 정렬**: flexbox + absolute positioning으로 화면 중앙 배치
4. **경로 관리**: pathKey를 통한 일관된 경로 관리

## 사용자 경험

### 명확한 안내
- "Page not found" 제목으로 즉시 상황 인지
- 친절한 사과 메시지
- 다음 행동(홈으로 돌아가기) 명확히 제시

### 쉬운 복구
- "Go back home" 버튼으로 원클릭 복귀
- 버튼 스타일(btn-outline-primary)로 행동 유도

### 시각적 차별화
- 어두운 배경(#333)으로 일반 페이지와 구분
- 전체 화면 중앙 정렬로 집중도 향상

## 활용 시나리오

1. **잘못된 URL 입력**: 타이핑 실수로 존재하지 않는 경로 접근
2. **오래된 북마크**: 더 이상 유효하지 않은 페이지 링크
3. **삭제된 콘텐츠**: 게시글 삭제 후 URL로 직접 접근
4. **개발 중 라우트**: 아직 구현되지 않은 페이지 접근