### PR TITLE
[refactor]: Layout 라우트 모듈화

### DIFF
--- a/src/app/browser-router.tsx
+++ b/src/app/browser-router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, RouterProvider, type RouteObject } from 'react-router-dom';
 import { homePageRoute } from '~pages/home/home-page.route';
+import { layoutRoute } from '~pages/layouts/layout.route';
 import { loginPageRoute } from '~pages/login/login-page.route';
 import { registerPageRoute } from '~pages/register/register-page.route';
 
@@ -9,11 +10,11 @@ export function BootstrappedRouter() {
 
 const browserRouter = createBrowserRouter([
   {
-    path: '/',
-    lazy: async () => ({
-      loader: (await import('~pages/layouts/layout.loader')).default,
-      Component: (await import('~pages/layouts/layout.ui')).default,
-    }),
-    children: [homePageRoute, registerPageRoute, loginPageRoute],
+    children: [
+      {
+        ...layoutRoute,
+        children: [homePageRoute, registerPageRoute, loginPageRoute],
+      },
+    ],
   },
 ] satisfies RouteObject[]);

--- a/src/pages/layouts/layout.route.ts
+++ b/src/pages/layouts/layout.route.ts
@@ -1,0 +1,8 @@
+import type { RouteObject } from 'react-router-dom';
+
+export const layoutRoute = {
+  lazy: {
+    loader: () => import('./layout.loader').then((module) => module.default),
+    Component: () => import('./layout.ui').then((module) => module.default),
+  },
+} satisfies RouteObject;


### PR DESCRIPTION
## Summary

브라우저 라우터에서 인라인으로 정의하던 레이아웃 라우트를 별도 모듈로 분리합니다.
다른 페이지 라우트들(home, login, register)과 동일한 패턴을 적용하여
일관된 라우트 구조를 유지하고 코드 가독성과 유지보수성을 향상시킵니다.

## Changes

### 레이아웃 라우트 모듈 생성
- **layout.route.ts**: layoutRoute 객체 정의
  - lazy loading으로 loader와 Component 동적 import
  - 다른 라우트 모듈(homePageRoute, loginPageRoute 등)과 동일한 패턴
  - RouteObject 타입 명시

### 브라우저 라우터 리팩토링
- **browser-router.tsx**: 레이아웃 라우트 설정 변경
  - layoutRoute 모듈 import 추가
  - 스프레드 연산자로 layoutRoute 적용
  - children 배열 구조 단순화

## Before & After

### Before (인라인 정의)
```typescript
const browserRouter = createBrowserRouter([
  {
    path: '/',
    lazy: async () => ({
      loader: (await import('~pages/layouts/layout.loader')).default,
      Component: (await import('~pages/layouts/layout.ui')).default,
    }),
    children: [homePageRoute, registerPageRoute, loginPageRoute],
  },
]);
```

### After (모듈화)
```typescript
// layout.route.ts
export const layoutRoute = {
  lazy: {
    loader: () => import('./layout.loader').then((module) => module.default),
    Component: () => import('./layout.ui').then((module) => module.default),
  },
} satisfies RouteObject;

// browser-router.tsx
const browserRouter = createBrowserRouter([
  {
    children: [
      {
        ...layoutRoute,
        children: [homePageRoute, registerPageRoute, loginPageRoute],
      },
    ],
  },
]);
```

## 개선 효과

### 일관성
- 모든 라우트가 동일한 모듈화 패턴 따름
- homePageRoute, loginPageRoute, registerPageRoute와 구조 통일

### 가독성
- browser-router.tsx의 코드 간소화
- 각 라우트의 책임이 명확히 분리
- 라우트 설정 파일에서 한눈에 구조 파악 가능

### 유지보수성
- 레이아웃 관련 설정이 한 곳(layout.route.ts)에 집중
- 레이아웃 변경 시 수정 범위 명확
- 라우트 추가/변경 시 일관된 패턴 적용 가능

### 타입 안전성
- RouteObject satisfies로 타입 검증
- IDE 자동완성 및 타입 체크 개선

## 기술적 특징

1. **Lazy Loading 일관성**: 모든 라우트가 동일한 lazy import 패턴 사용
2. **모듈 응집도**: 레이아웃 관련 코드가 layouts 디렉토리에 집중
3. **스프레드 연산자**: layoutRoute를 유연하게 확장 가능
4. **타입 안전성**: satisfies RouteObject로 컴파일 타임 검증

## 영향 범위

- **기능 변경 없음**: 순수 리팩토링으로 동작 동일
- **파일 변경**: 
  - 추가: `src/pages/layouts/layout.route.ts`
  - 수정: `src/app/browser-router.tsx`
- **번들 크기**: 변경 없음 (동일한 lazy loading 유지)