### PR TITLE
[fix] login/register 실패 시 불필요한 refresh API 호출 방지

### DIFF
--- a/src/shared/api/api.interceptors.ts
+++ b/src/shared/api/api.interceptors.ts
@@ -34,6 +34,10 @@ export function setupApiInterceptors(): void {
         return Promise.reject(error);
       }
 
+      if (originalConfig.url?.includes('users/login') || originalConfig.url?.includes('users/register')) {
+        return Promise.reject(error);
+      }
+
       if (originalConfig?.url?.includes('/users/refresh')) {
         if (TokenManager.shouldLogout(error)) {
           TokenManager.handleLogout(error);


### PR DESCRIPTION
## Summary

login/register 요청이 401 에러로 실패할 때 token refresh API가 불필요하게 호출되는 문제를 해결했습니다. privateApi response interceptor에서 login/register 엔드포인트를 조기에 감지하여 refresh 로직을 건너뛰도록 조건문을 추가했습니다.

Closes #69

## Changes

**src/shared/api/api.interceptors.ts** 수정
- privateApi response error interceptor에 조건문 추가
- 401 에러 처리 전 login/register 엔드포인트 확인
- 해당 엔드포인트는 refresh 로직 건너뛰고 즉시 reject
```typescript
// 401 에러 처리 전에 실행
if (originalConfig.url?.includes('users/login') || 
    originalConfig.url?.includes('users/register')) {
  return Promise.reject(error);
}
```

## 해결된 문제 (Issue #69)

### 기존 문제
- axios interceptor는 FIFO 방식으로 실행
- Auth interceptor가 먼저 등록되어 모든 401 에러에서 refresh 실행
- login/register 실패의 401도 refresh 트리거로 인식
- 불필요한 refresh API 호출 발생 (401 에러마다 2번 요청)

### 제약사항
- login API는 `withCredentials: true` 필요 (cookie 저장)
- publicApi 대신 privateApi 사용 불가피
- login/register는 정상적으로 401을 반환할 수 있음

### 해결 방법
login/register 경로를 조기 감지하여 refresh 로직 실행 전 즉시 반환

## 개선 효과

- **네트워크 최적화**: 401 에러마다 2번 → 1번 요청
- **응답 시간 단축**: refresh 대기 시간 제거
- **즉시 에러 전달**: login/register 실패를 바로 컴포넌트에 전달
- **명확한 의도**: 조건문으로 예외 케이스 명시

## 주요 변경 사항 요약

1. **조건문 추가** - login/register 경로 감지
2. **조기 return** - 해당 경로는 refresh 로직 스킵
3. **불필요한 API 호출 제거** - 네트워크 최적화