### PR TITLE
[chore] e2e 디렉토리 path alias 설정

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,20 +49,29 @@ const typescriptConfig = [
   // Airbnb React + TypeScript 설정
   ...configs.react.typescript,
 
-  // ✅ TypeScript Import Resolver 설정
+  // 기본 설정: src 파일은 tsconfig.json (참조를 통해 tsconfig.app.json 사용)
   {
     name: 'typescript/import-resolver',
+    files: ['src/**/*.{ts,tsx}'], // src 파일에만 적용
     settings: {
       'import-x/resolver-next': [
         createTypeScriptImportResolver({
-          // @types 디렉토리를 항상 확인
           alwaysTryTypes: true,
+          project: ['./tsconfig.json'], // src용 tsconfig
+        }),
+      ],
+    },
+  },
 
-          // ✅ tsconfig.app.json 사용 (애플리케이션 코드)
-          // project: './tsconfig.app.json', // 단일 파일 방식
-
-          // ✅ 여러 tsconfig 지원 (권장)
-          project: ['./tsconfig.json'],
+  // E2E 전용 설정: e2e 파일은 tsconfig.node.json 사용
+  {
+    name: 'typescript/import-resolver-e2e',
+    files: ['e2e/**/*.{ts,js}', 'playwright.config.ts'], // e2e 파일에만 적용
+    settings: {
+      'import-x/resolver-next': [
+        createTypeScriptImportResolver({
+          alwaysTryTypes: true,
+          project: ['./tsconfig.node.json'], // e2e용 tsconfig
         }),
       ],
     },

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -20,7 +20,13 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    /* E2E Path Alias */
+    "baseUrl": ".",
+    "paths": {
+      "~e2e/*": ["./e2e/*"]
+    }
   },
   "include": ["vite.config.ts", "playwright.config.ts", "e2e"]
 }


### PR DESCRIPTION
## Summary

e2e 테스트 파일에서 `~e2e` path alias를 사용할 수 있도록 설정했습니다. tsconfig.node.json에 path mapping을 추가하고 ESLint import resolver를 src/e2e로 분리하여 각 환경에 맞는 tsconfig를 참조하도록 구성했습니다.

Closes #89

## Changes

### tsconfig.node.json
- `baseUrl: "."` 추가
- `paths: { "~e2e/*": ["./e2e/*"] }` 추가
- e2e 디렉토리 내부에서 절대 경로 import 가능

### eslint.config.mjs
- TypeScript Import Resolver를 src/e2e로 분리
- **src 파일**: tsconfig.json 참조 (`files: 'src/**/*.{ts,tsx}'`)
- **e2e 파일**: tsconfig.node.json 참조 (`files: 'e2e/**/*.{ts,js}'`)
- 각 환경에 맞는 path alias 정확히 해석

### Playwright 자동 지원
- Playwright가 tsconfig.node.json의 baseUrl과 paths 자동 인식
- 별도 설정 없이 `~e2e` alias 사용 가능

## 해결된 문제 (Issue #89)

### 기존 문제
```typescript
// 상대 경로로 depth가 깊어짐
import { createUserByApi } from '../../utils/api-helper';
```

**문제점:**
- 파일 이동 시 모든 import 경로 수정 필요
- 깊은 depth로 가독성 저하
- 유지보수 어려움

### 해결 방법
```typescript
// path alias로 간결하게
import { createUserByApi } from '~e2e/utils/api-helper';
```

## 개선 효과

- **Import 간소화**: 상대 경로 대신 절대 경로 사용
- **가독성 향상**: depth 걱정 없이 명확한 경로
- **유지보수성**: 파일 이동 시 import 수정 최소화
- **ESLint 통합**: path alias 올바르게 인식 및 검증

## 주요 변경 사항 요약

1. **tsconfig.node.json** - baseUrl, paths 추가
2. **eslint.config.mjs** - src/e2e 환경별 resolver 분리
3. **~e2e alias** - e2e 테스트에서 절대 경로 사용 가능