### PR TITLE
[fix] e2e 디렉토리에서 React Hooks ESLint 규칙 비활성화

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -202,6 +202,19 @@ const testFilesOverrides = [
   },
 ];
 
+// E2E 파일에 대한 React Hooks 규칙 비활성화
+const e2eFilesOverrides = [
+  {
+    name: 'custom/e2e-overrides',
+    files: ['e2e/**/*.{js,ts}', 'playwright.config.ts', '**/fixtures/**/*.{js,ts}'],
+    rules: {
+      'react-hooks/rules-of-hooks': 'off',
+      'react-hooks/exhaustive-deps': 'off',
+      'import-x/no-extraneous-dependencies': 'off',
+    },
+  },
+];
+
 export default [
   // .gitignore에 명시된 파일/폴더를 ESLint에서 제외
   includeIgnoreFile(gitignorePath),
@@ -221,4 +234,6 @@ export default [
   ...environmentConfig,
   // 테스트 파일 예외 규칙
   ...testFilesOverrides,
+  // e2e 테스트 파일 예외 규칙
+  ...e2eFilesOverrides,
 ];


### PR DESCRIPTION
## Summary

Playwright fixtures의 `use` 콜백이 ESLint react-hooks/rules-of-hooks 규칙에 의해 불필요한 경고가 발생하는 문제를 해결했습니다. e2e 테스트 파일에서 React Hooks 관련 규칙을 비활성화하여 Playwright 테스트 작성 시 불필요한 ESLint 경고를 제거했습니다.

Closes #91

## Changes

### eslint.config.mjs
**e2eFilesOverrides 추가**
- `files`: e2e/**/*.{js,ts}, playwright.config.ts, **/fixtures/**/*.{js,ts}

**비활성화된 규칙:**
- `react-hooks/rules-of-hooks: off` - e2e는 React 환경 아님
- `react-hooks/exhaustive-deps: off` - hooks dependency 검증 불필요
- `import-x/no-extraneous-dependencies: off` - e2e는 테스트 환경이므로 테스트 의존성 자유롭게 사용

## 해결된 문제 (Issue #91)

### 기존 문제
```typescript
export const test = base.extend<AuthFixtures>({
  authenticatedToken: async ({ page }, use) => {
    // ❌ ESLint Error: react-hooks/rules-of-hooks
    // React Hook "use" is called in function that is neither 
    // a React function component nor a custom React Hook
    const user = await createUserByApi();
    await use(user.token);
  },
});
```

**원인:**
- Playwright의 `use` 콜백은 React Hook이 아님
- ESLint가 `use` prefix를 React Hook으로 오인
- 컴포넌트/커스텀 Hook 외부 사용으로 에러 발생

### 해결
e2e 테스트 파일에 대해서만 React Hooks 규칙 비활성화
- Playwright 테스트는 순수 JS/TS 환경
- React 관련 규칙 적용 불필요

## 개선 효과

- **불필요한 경고 제거**: Playwright fixtures에서 `use` 콜백 정상 사용
- **개발 경험**: 불필요한 ESLint 경고 제거
- **규칙 충돌 방지**: e2e 테스트 작성 시 React 규칙 간섭 없음
- **성능 향상**: 불필요한 규칙 검사 제거

## 주요 변경 사항 요약

1. **e2eFilesOverrides** - e2e 전용 ESLint 설정 추가
2. **React Hooks 규칙 비활성화** - rules-of-hooks, exhaustive-deps off
3. **적용 범위** - e2e/**, playwright.config.ts, fixtures